### PR TITLE
fix(radio): fixed a styling issue in the Radio component

### DIFF
--- a/.changeset/fifty-dolphins-provide.md
+++ b/.changeset/fifty-dolphins-provide.md
@@ -1,0 +1,6 @@
+---
+'@banana-ui/banana': patch
+'@banana-ui/react': patch
+---
+
+Fixed a styling issue in the Radio component.

--- a/.dumi/tsconfig.json
+++ b/.dumi/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/docs/example/Radio/demos/disabled.tsx
+++ b/docs/example/Radio/demos/disabled.tsx
@@ -17,7 +17,7 @@ export default function Disabled() {
         </Radio>
       </RadioGroup>
 
-      <RadioGroup disabled>
+      <RadioGroup disabled value="banana">
         <Radio value="banana">Banana🍌</Radio>
         <Radio value="apple">Apple🍎</Radio>
         <Radio value="cherry">Cherry🍒</Radio>

--- a/packages/banana/src/radio/index.styles.ts
+++ b/packages/banana/src/radio/index.styles.ts
@@ -40,7 +40,7 @@ export default [
 
     .radio--checked:not(.radio--disabled) .radio__control {
       background-color: var(--banana-color-primary, ${unsafeCSS(Var.ColorPrimary)});
-      border-color: var(--banana-color-primary, ${unsafeCSS(Var.ColorPrimary)});
+      border: none;
     }
 
     .radio--checked:not(.radio--disabled) .radio__control::after {


### PR DESCRIPTION
Radio组件的control部分，外面的大圆圈和里面的小圆圈之间的居中用的是绝对定位+flex布局，在选中状态下如果有radius会导致居中有1px的偏移。