### PR TITLE
ci(ci): fixed ci

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,6 +24,10 @@ jobs:
       # 组件库打包
       - name: Build packages
         run: pnpm build
+
+      - name: Before Test
+        run: pnpm install playwright -g && pnpm exec playwright install
+
       # 测试
       - name: Test
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Before Test
+        run: pnpm install playwright -g && pnpm exec playwright install
+
       # 测试
       - name: Test
         run: pnpm test


### PR DESCRIPTION
项目使用的测试框架`@web/test-runner-playwright`的依赖更新后，运行单元测试会提示报错。
原依赖版本/出问题的依赖版本：
- playwright: 1.37.1
+ playwright: 1.42.1

报错信息：
![img_v3_0297_07dd3f21-44f7-4874-ba93-3ce829a0715g](https://github.com/FriedRiceNoodles/banana-ui/assets/53017934/97bab495-21b1-4464-bf73-06f2e0b92c2b)


这看起来不像本项目的改动带来的问题，怀疑是`@web/test-runner-playwright`与其上游依赖（`playwright`）的变更有关。

这里先通过修改workflow文件来规避错误。